### PR TITLE
Clean composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
+    - 7.0
 
 before_script: composer install
 script: phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,5 @@ php:
     - 5.5
     - 5.6
 
-before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install
-
+before_script: composer install
 script: phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,6 @@
         "symfony/property-access": "^2.3 || ^3.0"
     },
 
-    "require-dev": {
-        "phpunit/phpunit": "~3.7"
-    },
-
     "autoload": {
         "psr-4": {
             "Clearbit\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
 
     "require": {
-        "php": ">=5.4.0",
-        "guzzle/guzzle": "~3.9",
+        "php": "^5.4 || ^7.0",
+        "guzzle/guzzle": "^3.9",
         "symfony/property-access": "^2.3 || ^3.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
         "guzzle/guzzle": "~3.9",
-        "symfony/property-access": "~2.3"
+        "symfony/property-access": "^2.3 || ^3.0"
     },
 
     "require-dev": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ Guzzle\Tests\GuzzleTestCase::setServiceBuilder(
             'clearbit' =>  [
                 'class' => 'Clearbit\Client',
                 'params' => [
-                    'api_token' => $_SERVER['API_TOKEN']
+                    'api_token' => array_key_exists('API_TOKEN', $_SERVER) ? $_SERVER['API_TOKEN'] : null
                 ]
             ]
         ]


### PR DESCRIPTION
- phpunit is already installed on travis... let's use it, instead of something that is deprecated
- allow symfony 3.0 components
- use travis' composer binary, should not be our concern to run with the latest version
